### PR TITLE
Fix window leak when split-screen is released

### DIFF
--- a/sip/src/com/android/services/telephony/sip/SipEditor.java
+++ b/sip/src/com/android/services/telephony/sip/SipEditor.java
@@ -17,6 +17,8 @@
 package com.android.services.telephony.sip;
 
 import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
 import android.content.Intent;
 import android.net.sip.SipProfile;
 import android.os.Bundle;
@@ -66,6 +68,39 @@ public class SipEditor extends PreferenceActivity
     private SipProfile mOldProfile;
     private Button mRemoveButton;
     private SipAccountRegistry mSipAccountRegistry;
+
+    /**
+     * Dialog fragment class to be used for displaying an alert dialog.
+     */
+    public static class AlertDialogFragment extends DialogFragment {
+        private static final String KEY_MESSAGE = "message";
+
+        /**
+         * Initialize the AlertDialogFragment instance.
+         *
+         * @param message the dialog message to display.
+         * @return the AlertDialogFragment.
+         */
+        public static AlertDialogFragment newInstance(String message) {
+            AlertDialogFragment frag = new AlertDialogFragment();
+            Bundle args = new Bundle();
+            args.putString(KEY_MESSAGE, message);
+            frag.setArguments(args);
+            return frag;
+        }
+
+        @Override
+        public Dialog onCreateDialog(Bundle savedInstanceState) {
+            String message = getArguments().getString(KEY_MESSAGE);
+
+            return new AlertDialog.Builder(getActivity())
+                    .setTitle(android.R.string.dialog_alert_title)
+                    .setIconAttribute(android.R.attr.alertDialogIcon)
+                    .setMessage(message)
+                    .setPositiveButton(R.string.alert_dialog_ok, null)
+                    .create();
+        }
+    }
 
     enum PreferenceKey {
         Username(R.string.username, 0, R.string.default_preference_summary_username),
@@ -285,17 +320,9 @@ public class SipEditor extends PreferenceActivity
             if (VERBOSE) log("Home button clicked, don't show dialog: " + message);
             return;
         }
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                new AlertDialog.Builder(SipEditor.this)
-                        .setTitle(android.R.string.dialog_alert_title)
-                        .setIconAttribute(android.R.attr.alertDialogIcon)
-                        .setMessage(message)
-                        .setPositiveButton(R.string.alert_dialog_ok, null)
-                        .show();
-            }
-        });
+
+        AlertDialogFragment newFragment = AlertDialogFragment.newInstance(message);
+        newFragment.show(getFragmentManager(), null);
     }
 
     private boolean isEditTextEmpty(PreferenceKey key) {


### PR DESCRIPTION
When split-screen is released while AlertDialog shown in SipEditor,
window leak occurs. User can't navigate back with the Back button
afterward. To avoid this, use DialogFragment instead of AlertDialog.

Bug: 32493780
Change-Id: Iddbd04b99f279fccabdf698acff1311612e3a8d6