### PR TITLE
VoicemailSettingsActivity: Fix some NPEs

### DIFF
--- a/src/com/android/phone/settings/VoicemailSettingsActivity.java
+++ b/src/com/android/phone/settings/VoicemailSettingsActivity.java
@@ -302,9 +302,7 @@ public class VoicemailSettingsActivity extends PreferenceActivity
                 mVoicemailVisualVoicemail.setOnPreferenceChangeListener(this);
                 mVoicemailVisualVoicemail.setChecked(
                         VisualVoicemailSettingsUtil.isEnabled(this, mPhoneAccountHandle));
-                if (!isVisualVoicemailActivated()) {
-                    prefSet.removePreference(mVoicemailChangePinPreference);
-                }
+                mVoicemailChangePinPreference.setEnabled(isVisualVoicemailActivated());
             } else {
                 prefSet.removePreference(mVoicemailVisualVoicemail);
                 prefSet.removePreference(mVoicemailChangePinPreference);
@@ -434,11 +432,7 @@ public class VoicemailSettingsActivity extends PreferenceActivity
             VisualVoicemailSettingsUtil
                     .setEnabled(mPhone.getContext(), mPhoneAccountHandle, isEnabled);
             PreferenceScreen prefSet = getPreferenceScreen();
-            if (isVisualVoicemailActivated()) {
-                prefSet.addPreference(mVoicemailChangePinPreference);
-            } else {
-                prefSet.removePreference(mVoicemailChangePinPreference);
-            }
+            mVoicemailChangePinPreference.setEnabled(isVisualVoicemailActivated());
         }
 
         // Always let the preference setting proceed.


### PR DESCRIPTION
If visual voicemail is supported, the PIN prefeerence is removed
when visual voice mail is disabled and re-added when enabled. This
causes NPEs in different parts of the code. Instead of adding the
needed checks not to crash, never remove the PIN preference if
visual voicemail is supported and simply enable/disable it.

BUGBASH-315

Change-Id: I6394c05cbd7adada1835e3cb89a535d6ffa9c2f4