### PR TITLE
[PATCH] Allow to disable the new scan API for manual network search.

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -247,4 +247,9 @@
          When this is true, the Telephony stack is able to add additional audio to the outgoing
          audio stream which the remote party will be able to hear. -->
     <bool name="config_support_telephony_audio_device">false</bool>
+    <!-- Flag indicating if network query through TelephonyManager.requestNetworkScan() should be
+         disabled.
+         If set to true, it will send network query through Phone.getAvailableNetworks() directly
+         rather than attempt to query through TelephonyManager.requestNetworkScan() first. -->
+    <bool name="config_requestNetworkScan_disable">false</bool>
 </resources>


### PR DESCRIPTION
From 98df93f88b9a6bc94a5e2625bbc0382b0e381d97 Mon Sep 17 00:00:00 2001
From: Kyle Harrison <khwebmail@gmail.com>
Date: Fri, 5 Apr 2019 15:58:01 +0100

The implementation to attempt new API and then fallback after
error is generic but may be not efficient. For the devices that
is not capable of using new API, it lengthens the network search
because of the new API scan trial in the first place and may fail
if the error is not properly caught.
(Refer to Ifebbac9965a40acaff0d50d32ca8603c72a6a77f for details)

As an alternative, this commit provides a config for devices that
are known as not capable of using new API to disable new API scan
and start network search through old API directly.

Change-Id: Iac3d70d91ee449a3a2ce4e5729176e09cb80b711